### PR TITLE
Expr try

### DIFF
--- a/langs/tla/ExprMarker.scala
+++ b/langs/tla/ExprMarker.scala
@@ -1,0 +1,126 @@
+// Copyright 2024-2025 Forja Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forja.langs.tla
+
+import cats.syntax.all.given
+
+import forja.*
+import forja.dsl.*
+import forja.wf.Wellformed
+
+import TLAReader.*
+
+object ExprMarker extends PassSeq:
+
+  lazy val passes = List(
+    buildExpressions,
+  )
+
+  object ExprTry extends Token
+  def inputWellformed: Wellformed = TLAParser.outputWellformed // .makeDerived:
+    // ExprTry ::= Atom
+    // TLAReader.groupTokens.foreach: tok =>
+    //     tok.addCases(ExprTry)
+
+  object buildExpressions extends Pass:
+    val wellformed = prevWellformed.makeDerived:
+      val removedCases = Seq(
+        TLAReader.StringLiteral,
+        TLAReader.NumberLiteral,
+        TLAReader.TupleGroup,
+        // TODO: remove cases
+      )
+      TLAReader.groupTokens.foreach: tok =>
+        tok.removeCases(removedCases*)
+        tok.addCases(lang.Expr)
+
+      //lang.Expr.deleteShape()
+      lang.Expr.importFrom(lang.wf)
+      lang.Expr.addCases(lang.Expr)
+
+
+    val rules = 
+      pass(once = false, strategy = pass.bottomUp)
+        .rules:
+          // Number and String Literals can be parsed directly
+          on(
+            TLAReader.NumberLiteral,
+          ).rewrite: lit =>
+            splice(lang.Expr(lang.Expr.NumberLiteral().like(lit)))
+          | on(
+            TLAReader.StringLiteral,
+          ).rewrite: lit =>
+            splice(lang.Expr(lang.Expr.StringLiteral().like(lit)))
+          // Isolated Alpha can be parsed
+          | on(
+            skip(ExprTry)
+            ~ field(TLAReader.Alpha)
+            ~ eof
+          ).rewrite: id =>
+            splice(
+              lang.Expr(
+                lang.Expr.OpCall(
+                  lang.Id().like(id),
+                  lang.Expr.OpCall.Params(),
+                )
+              )
+            )
+          // Braces Group is complete when the elements are parsed
+          | on(
+              skip(ExprTry)
+              ~ field(
+                tok(TLAReader.BracesGroup) *>
+                  children:
+                    field(repeatedSepBy(`,`)(lang.Expr))
+                    ~ eof
+              )
+              ~ trailing
+          ).rewrite: exprs =>
+            splice(
+              lang.Expr(
+                lang.Expr.SetLiteral(exprs.iterator.map(_.unparent())),
+              )
+            ) 
+          // If the braces group is not complete, mark the next element as ExprTry
+          // | on(
+          //     parent(tok(TLAReader.BracesGroup) *> rightSibling(ExprTry)) *>
+          //     field(lang.Expr)
+          //     ~ field(`,` *> rightSibling(not(ExprTry)))
+          //   ).rewrite: (expr, comma) =>
+          //     splice(expr, comma, ExprTry())
+          // Expr has been parsed and ExprTry can be removed
+          | on(
+            skip(ExprTry)
+            ~ field(lang.Expr)
+            ~ eof
+          ).rewrite: expr =>
+            splice(expr.unparent())
+  end buildExpressions
+
+  object removeNestedExpr extends Pass:
+    val wellformed = prevWellformed.makeDerived:
+      lang.Expr.removeCases(lang.Expr)
+
+    val rules = 
+      pass(once = true, strategy = pass.bottomUp)
+        .rules:
+          on(
+            tok(lang.Expr) *>
+              onlyChild(lang.Expr),
+          ).rewrite: child =>
+            splice(
+              child.unparent(),
+            )
+  end removeNestedExpr

--- a/langs/tla/ExprMarker.scala
+++ b/langs/tla/ExprMarker.scala
@@ -29,10 +29,7 @@ object ExprMarker extends PassSeq:
   )
 
   object ExprTry extends Token
-  def inputWellformed: Wellformed = TLAParser.outputWellformed // .makeDerived:
-    // ExprTry ::= Atom
-    // TLAReader.groupTokens.foreach: tok =>
-    //     tok.addCases(ExprTry)
+  def inputWellformed: Wellformed = TLAParser.outputWellformed
 
   object buildExpressions extends Pass:
     val wellformed = prevWellformed.makeDerived:
@@ -46,7 +43,7 @@ object ExprMarker extends PassSeq:
         tok.removeCases(removedCases*)
         tok.addCases(lang.Expr)
 
-      //lang.Expr.deleteShape()
+      lang.Expr.deleteShape()
       lang.Expr.importFrom(lang.wf)
       lang.Expr.addCases(lang.Expr)
 

--- a/langs/tla/ExprMarker.scala
+++ b/langs/tla/ExprMarker.scala
@@ -91,12 +91,12 @@ object ExprMarker extends PassSeq:
               )
             ) 
           // If the braces group is not complete, mark the next element as ExprTry
-          // | on(
-          //     parent(tok(TLAReader.BracesGroup) *> rightSibling(ExprTry)) *>
-          //     field(lang.Expr)
-          //     ~ field(`,` *> rightSibling(not(ExprTry)))
-          //   ).rewrite: (expr, comma) =>
-          //     splice(expr, comma, ExprTry())
+          | on(
+              parent(tok(TLAReader.BracesGroup) *> rightSibling(ExprTry)) *>
+              field(lang.Expr)
+              ~ field(`,` *> rightSibling(not(ExprTry)))
+            ).rewrite: (expr, comma) =>
+              splice(expr, comma, ExprTry())
           // Expr has been parsed and ExprTry can be removed
           | on(
             skip(ExprTry)

--- a/langs/tla/ExprMarker.test.scala
+++ b/langs/tla/ExprMarker.test.scala
@@ -60,7 +60,7 @@ class ExprMarkerTests extends munit.FunSuite:
         Node.Top(lang.Expr(lang.Expr.StringLiteral("string"))),
     )
 
-  test("ParanthesisGroup"):
+  test("ParenthesesGroup"):
     assertEquals(
         Node.Top(ExprTry(), TLAReader.ParenthesesGroup(
           TLAReader.NumberLiteral("1")

--- a/langs/tla/ExprMarker.test.scala
+++ b/langs/tla/ExprMarker.test.scala
@@ -254,6 +254,33 @@ class ExprMarkerTests extends munit.FunSuite:
     )
 
 
+  test("If"):
+    assertEquals(
+      Node.Top(
+        ExprTry(),
+        defns.IF(),
+        TLAReader.Alpha("A"),
+        defns.THEN(),
+        TLAReader.NumberLiteral("1"),
+        defns.ELSE(),
+        TLAReader.NumberLiteral("2"),
+      ).parseNode,
+      Node.Top(
+        lang.Expr(
+          lang.Expr.If(
+            lang.Expr(
+              lang.Expr.OpCall(
+                lang.Id("A"),
+                lang.Expr.OpCall.Params(),
+              ),
+            ),
+            lang.Expr(lang.Expr.NumberLiteral("1")),
+            lang.Expr(lang.Expr.NumberLiteral("2")),
+          ),
+        ),
+      )
+    )
+  
   test("Case"):
     assertEquals(
       Node.Top(
@@ -326,43 +353,64 @@ class ExprMarkerTests extends munit.FunSuite:
       )
     )
 
-
+  // This test assumes that TLAParser has parsed the definitions and has inserted the ExprTry before the let body.
+  // TODO: I am not sure what kind of node I should pass to lang.Operator. It complains if it is an Expr.
   // test("LET"):
   //   assertEquals(
-  //     """LET x == 1
-  //       |y == 2
-  //       |IN  {y, x}""".stripMargin.parseStr,
   //     Node.Top(
-  //       lang.Expr.Let(
-  //         lang.Expr.Let.Defns(
-  //           lang.Operator(
-  //             lang.Id("x"),
-  //             lang.Operator.Params(),
-  //             lang.Expr(lang.Expr.NumberLiteral("1")),
-  //           ),
-  //           lang.Operator(
-  //             lang.Id("y"),
-  //             lang.Operator.Params(),
-  //             lang.Expr(lang.Expr.NumberLiteral("2")),
-  //           ),
+  //       ExprTry(),
+  //       TLAReader.LetGroup(
+  //         lang.Operator(
+  //           lang.Id("X"),
+  //           lang.Operator.Params(),
+  //           lang.Expr(lang.Expr.NumberLiteral("1")),
   //         ),
-  //         lang.Expr(
-  //           lang.Expr.SetLiteral(
-  //             lang.Expr(
-  //               lang.Expr.OpCall(
-  //                 lang.Id("y"),
-  //                 lang.Expr.OpCall.Params(),
-  //               ),
+  //         lang.Operator(
+  //           lang.Id("Y"),
+  //           lang.Operator.Params(),
+  //           lang.Expr(lang.Expr.NumberLiteral("2")),
+  //         ),
+  //       ),
+  //       ExprTry(),
+  //       TLAReader.BracesGroup(
+  //         TLAReader.Alpha("X"),
+  //         TLAReader.`,`(","),
+  //         TLAReader.Alpha("Y"),
+  //       )
+  //     ).parseNode,
+  //     Node.Top(
+  //       lang.Expr(
+  //         lang.Expr.Let(
+  //           lang.Expr.Let.Defns(
+  //             lang.Operator(
+  //               lang.Id("X"),
+  //               lang.Operator.Params(),
+  //               lang.Expr(lang.Expr.NumberLiteral("1")),
   //             ),
-  //             lang.Expr(
-  //               lang.Expr.OpCall(
-  //                 lang.Id("x"),
-  //                 lang.Expr.OpCall.Params(),
+  //             lang.Operator(
+  //               lang.Id("Y"),
+  //               lang.Operator.Params(),
+  //               lang.Expr(lang.Expr.NumberLiteral("2")),
+  //             ),
+  //           ),
+  //           lang.Expr(
+  //             lang.Expr.SetLiteral(
+  //               lang.Expr(
+  //                 lang.Expr.OpCall(
+  //                   lang.Id("Y"),
+  //                   lang.Expr.OpCall.Params(),
+  //                 ),
+  //               ),
+  //               lang.Expr(
+  //                 lang.Expr.OpCall(
+  //                   lang.Id("X"),
+  //                   lang.Expr.OpCall.Params(),
+  //                 ),
   //               ),
   //             ),
   //           ),
   //         ),
   //       ),
-  //     ),
+  //     )
   //   )
 

--- a/langs/tla/ExprMarker.test.scala
+++ b/langs/tla/ExprMarker.test.scala
@@ -40,7 +40,7 @@ class ExprMarkerTests extends munit.FunSuite:
           ),
         ),
       )
-        // instrumentWithTracer(forja.manip.RewriteDebugTracer(os.pwd / "dbg_exprmarker")):
+      // instrumentWithTracer(forja.manip.RewriteDebugTracer(os.pwd / "dbg_exprmarker")):
         ExprMarker(freshTop)
       Node.Top(
         freshTop(lang.Module)(lang.Module.Defns)(lang.Operator)(
@@ -70,7 +70,7 @@ class ExprMarkerTests extends munit.FunSuite:
     // TODO: paranthesis with op
 
 
-  test("Set Literal"):
+  test("SetLiteral"):
     // empty set    
     assertEquals(
       Node.Top(ExprTry(), TLAReader.BracesGroup()).parseNode,
@@ -78,13 +78,16 @@ class ExprMarkerTests extends munit.FunSuite:
     )
     // set with three elements
     assertEquals(
-      Node.Top(ExprTry(), TLAReader.BracesGroup(
-        TLAReader.NumberLiteral("1"),
-        TLAReader.`,`(","),
-        TLAReader.NumberLiteral("2"),
-        TLAReader.`,`(","),
-        TLAReader.NumberLiteral("3")
-      )).parseNode,
+      Node.Top(
+        ExprTry(),
+        TLAReader.BracesGroup(
+          TLAReader.NumberLiteral("1"),
+          TLAReader.`,`(","),
+          TLAReader.NumberLiteral("2"),
+          TLAReader.`,`(","),
+          TLAReader.NumberLiteral("3")
+        )
+      ).parseNode,
       Node.Top(
         lang.Expr(
           lang.Expr.SetLiteral(
@@ -97,13 +100,16 @@ class ExprMarkerTests extends munit.FunSuite:
     )
     // nested sets
     assertEquals(
-      Node.Top(ExprTry(), TLAReader.BracesGroup(
-        TLAReader.NumberLiteral("1"),
-        TLAReader.`,`(","),
-        TLAReader.BracesGroup(),
-        TLAReader.`,`(","),
-        TLAReader.NumberLiteral("3")
-      )).parseNode,
+      Node.Top(
+        ExprTry(),
+        TLAReader.BracesGroup(
+          TLAReader.NumberLiteral("1"),
+          TLAReader.`,`(","),
+          TLAReader.BracesGroup(),
+          TLAReader.`,`(","),
+          TLAReader.NumberLiteral("3")
+        )
+      ).parseNode,
       Node.Top(
         lang.Expr(
           lang.Expr.SetLiteral(
@@ -115,7 +121,7 @@ class ExprMarkerTests extends munit.FunSuite:
       )
     )
 
-  test("Tuple Literal"):
+  test("TupleLiteral"):
     // empty tuple
     assertEquals(
       Node.Top(ExprTry(), TLAReader.TupleGroup()).parseNode,
@@ -123,19 +129,61 @@ class ExprMarkerTests extends munit.FunSuite:
     )
     // tuple with three elements
     assertEquals(
-      Node.Top(ExprTry(), TLAReader.TupleGroup(
-        TLAReader.NumberLiteral("1"),
-        TLAReader.`,`(","),
-        TLAReader.StringLiteral("two"),
-        TLAReader.`,`(","),
-        TLAReader.NumberLiteral("3")
-      )).parseNode,
+      Node.Top(
+        ExprTry(),
+        TLAReader.TupleGroup(
+          TLAReader.NumberLiteral("1"),
+          TLAReader.`,`(","),
+          TLAReader.StringLiteral("two"),
+          TLAReader.`,`(","),
+          TLAReader.NumberLiteral("3")
+        )
+      ).parseNode,
       Node.Top(
         lang.Expr(
           lang.Expr.TupleLiteral(
             lang.Expr(lang.Expr.NumberLiteral("1")),
             lang.Expr(lang.Expr.StringLiteral("two")),
             lang.Expr(lang.Expr.NumberLiteral("3")),
+          ),
+        )
+      )
+    )
+
+  test("RecordLiteral"):
+    // record with three fields
+    assertEquals(
+      Node.Top(
+        ExprTry(), 
+        TLAReader.SqBracketsGroup(
+          TLAReader.Alpha("X"),
+          TLAReader.`|->`("|->"),
+          TLAReader.NumberLiteral("1"),
+          TLAReader.`,`(","),
+          TLAReader.Alpha("Y"),
+          TLAReader.`|->`("|->"),
+          TLAReader.NumberLiteral("2"),
+          TLAReader.`,`(","),
+          TLAReader.Alpha("Z"),
+          TLAReader.`|->`("|->"),
+          TLAReader.NumberLiteral("3"),
+        )
+      ).parseNode,
+      Node.Top(
+        lang.Expr(
+          lang.Expr.RecordLiteral(
+            lang.Expr.RecordLiteral.Field(
+              lang.Id("X"),
+              lang.Expr(lang.Expr.NumberLiteral("1")),
+            ),
+            lang.Expr.RecordLiteral.Field(
+              lang.Id("Y"),
+              lang.Expr(lang.Expr.NumberLiteral("2")),
+            ),
+            lang.Expr.RecordLiteral.Field(
+              lang.Id("Z"),
+              lang.Expr(lang.Expr.NumberLiteral("3")),
+            )
           ),
         )
       )

--- a/langs/tla/ExprMarker.test.scala
+++ b/langs/tla/ExprMarker.test.scala
@@ -115,6 +115,33 @@ class ExprMarkerTests extends munit.FunSuite:
       )
     )
 
+  test("Tuple Literal"):
+    // empty tuple
+    assertEquals(
+      Node.Top(ExprTry(), TLAReader.TupleGroup()).parseNode,
+      Node.Top(lang.Expr(lang.Expr.TupleLiteral()))
+    )
+    // tuple with three elements
+    assertEquals(
+      Node.Top(ExprTry(), TLAReader.TupleGroup(
+        TLAReader.NumberLiteral("1"),
+        TLAReader.`,`(","),
+        TLAReader.StringLiteral("two"),
+        TLAReader.`,`(","),
+        TLAReader.NumberLiteral("3")
+      )).parseNode,
+      Node.Top(
+        lang.Expr(
+          lang.Expr.TupleLiteral(
+            lang.Expr(lang.Expr.NumberLiteral("1")),
+            lang.Expr(lang.Expr.StringLiteral("two")),
+            lang.Expr(lang.Expr.NumberLiteral("3")),
+          ),
+        )
+      )
+    )
+  
+
 
   test("Case"):
     assertEquals(

--- a/langs/tla/ExprMarker.test.scala
+++ b/langs/tla/ExprMarker.test.scala
@@ -1,0 +1,119 @@
+// Copyright 2024-2025 Forja Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forja.langs.tla
+
+import forja.*
+import forja.dsl.*
+// import forja.source.{Source, SourceRange}
+import ExprMarker.ExprTry
+
+// Run with:
+// scala-cli test . -- '*ExprMarker*'
+
+class ExprMarkerTests extends munit.FunSuite:
+  extension (top: Node.Top)
+    def parseNode: Node.Top =
+      val freshTop = Node.Top(
+        lang.Module(
+          lang.Id("TestMod"),
+          lang.Module.Extends(),
+          lang.Module.Defns(
+            lang.Operator(
+              lang.Id("test"),
+              lang.Operator.Params(),
+              lang.Expr(
+                top.unparentedChildren,
+              ),
+            ),
+          ),
+        ),
+      )
+      ExprMarker(freshTop)
+      Node.Top(
+        freshTop(lang.Module)(lang.Module.Defns)(lang.Operator)(
+          lang.Expr,
+        ).unparentedChildren,
+      )
+
+  test("NumberLiteral"):
+    assertEquals(
+        Node.Top(TLAReader.NumberLiteral("1")).parseNode,
+        Node.Top(lang.Expr(lang.Expr.NumberLiteral("1"))),
+    )
+    assertEquals(
+        Node.Top(ExprTry(), TLAReader.NumberLiteral("1")).parseNode,
+        Node.Top(lang.Expr(lang.Expr.NumberLiteral("1"))),
+    )
+
+  test("StringLiteral"):
+    assertEquals(
+        Node.Top(TLAReader.StringLiteral("string")).parseNode,
+        Node.Top(lang.Expr(lang.Expr.StringLiteral("string"))),
+    )
+
+    assertEquals(
+        Node.Top(ExprTry(), TLAReader.StringLiteral("string")).parseNode,
+        Node.Top(lang.Expr(lang.Expr.StringLiteral("string"))),
+    )
+
+  test("Alpha"):
+      assertEquals(
+        Node.Top(ExprTry(), TLAReader.Alpha("x")).parseNode,
+        Node.Top(
+          lang.Expr(lang.Expr.OpCall(lang.Id("x"), lang.Expr.OpCall.Params()))
+        )
+      )
+
+  // test("Set Literal"):
+  //   assertEquals(
+  //     Node.Top(ExprTry(), TLAReader.BracesGroup(
+  //       TLAReader.NumberLiteral("1"),
+  //       TLAReader.`,`(","),
+  //       TLAReader.NumberLiteral("2"),
+  //       TLAReader.`,`(","),
+  //       TLAReader.NumberLiteral("3")
+  //     )).parseNode,
+  //     Node.Top(
+  //       lang.Expr(
+  //         lang.Expr.SetLiteral(
+  //           lang.Expr(lang.Expr.NumberLiteral("1")),
+  //           lang.Expr(lang.Expr.NumberLiteral("2")),
+  //           lang.Expr(lang.Expr.NumberLiteral("3")),
+  //         ),
+  //       )
+  //     )
+  //   )
+  //   assertEquals(
+  //     Node.Top(ExprTry(), TLAReader.BracesGroup(
+  //       TLAReader.NumberLiteral("1"),
+  //       TLAReader.`,`(","),
+  //       TLAReader.BracesGroup(),
+  //       TLAReader.`,`(","),
+  //       TLAReader.NumberLiteral("3")
+  //     )).parseNode,
+  //     Node.Top(
+  //       lang.Expr(
+  //         lang.Expr.SetLiteral(
+  //           lang.Expr(lang.Expr.NumberLiteral("1")),
+  //           lang.Expr(lang.Expr.SetLiteral()),
+  //           lang.Expr(lang.Expr.NumberLiteral("3")),
+  //         ),
+  //       )
+  //     )
+  //   )
+  //   assertEquals(
+  //     Node.Top(ExprTry(), TLAReader.BracesGroup()).parseNode,
+  //     Node.Top(lang.Expr(lang.Expr.SetLiteral())),
+  //   )

--- a/langs/tla/ExprMarker.test.scala
+++ b/langs/tla/ExprMarker.test.scala
@@ -60,6 +60,19 @@ class ExprMarkerTests extends munit.FunSuite:
         Node.Top(lang.Expr(lang.Expr.StringLiteral("string"))),
     )
 
+  test("Id"):
+    assertEquals(
+        Node.Top(ExprTry(), TLAReader.Alpha("X")).parseNode,
+        Node.Top(
+          lang.Expr(
+            lang.Expr.OpCall(
+              lang.Id("X"),
+              lang.Expr.OpCall.Params()
+            )
+          )
+        )
+    )
+
   test("ParenthesesGroup"):
     assertEquals(
         Node.Top(ExprTry(), TLAReader.ParenthesesGroup(
@@ -189,6 +202,56 @@ class ExprMarkerTests extends munit.FunSuite:
       )
     )
   
+  test("Projection (Record Field Acess)"):
+    assertEquals(
+      Node.Top(
+        ExprTry(),
+        TLAReader.Alpha("X"),
+        defns.`.`("."),
+        TLAReader.Alpha("Y")
+      ).parseNode,
+      Node.Top(
+        lang.Expr(
+          lang.Expr.Project(
+            lang.Expr(
+              lang.Expr.OpCall(
+                lang.Id("X"),
+                lang.Expr.OpCall.Params(),
+              ),
+            ),
+            lang.Id("Y"),
+          ),
+        )
+      )
+    )
+    assertEquals(
+      Node.Top(
+        ExprTry(),
+        TLAReader.Alpha("X"),
+        defns.`.`("."),
+        TLAReader.Alpha("Y"),
+        defns.`.`("."),
+        TLAReader.Alpha("Z")
+      ).parseNode,
+      Node.Top(
+        lang.Expr(
+          lang.Expr.Project(
+            lang.Expr(
+              lang.Expr.Project(
+                lang.Expr(
+                  lang.Expr.OpCall(
+                    lang.Id("X"),
+                    lang.Expr.OpCall.Params(),
+                  )
+                ),
+                lang.Id("Y"),
+              )
+            ),
+            lang.Id("Z")
+          )
+        )
+      )
+    )
 
 
   test("Case"):

--- a/langs/tla/TLAReader.scala
+++ b/langs/tla/TLAReader.scala
@@ -20,6 +20,7 @@ import forja.*
 import forja.dsl.*
 import forja.source.{Reader, SourceRange}
 import forja.wf.Wellformed
+import forja.langs.tla.ExprMarker.ExprTry
 
 object TLAReader extends Reader:
   lazy val groupTokens: List[Token] = List(
@@ -54,6 +55,8 @@ object TLAReader extends Reader:
         Comment,
         DashSeq,
         EqSeq,
+        //
+        ExprTry,
       )
         | choice(NonAlpha.instances.toSet)
         | choice(allOperators.toSet)
@@ -70,6 +73,7 @@ object TLAReader extends Reader:
     NumberLiteral ::= Atom
     Alpha ::= Atom
     LaTexLike ::= Atom
+    ExprTry ::= Atom
 
     StepMarker ::= fields(
       choice(StepMarker.Num, StepMarker.Plus, StepMarker.Star),

--- a/src/wf/Wellformed.scala
+++ b/src/wf/Wellformed.scala
@@ -554,6 +554,15 @@ object Wellformed:
             throw IllegalArgumentException(
               s"$token's shape is not appropriate for adding cases ($shape)",
             )
+      
+      def deleteShape(): Unit =
+        token match
+          case Node.Top =>
+            require(topShapeOpt.nonEmpty)
+            topShapeOpt = None
+          case token: Token =>
+            require(assigns.contains(token))
+            assigns.remove(token)
 
       def importFrom(wf2: Wellformed): Unit =
         def fillFromShape(shape: Shape): Unit =


### PR DESCRIPTION
First attempt on a TLA+ parser without `rawExpression`

So far, it should be able to parse:
- NumberLiteral
- StringLiteral
- Identifiers (OpCall without parameteres)
- Tuple Literals
- Set Literals
- Record Literals
- Projection (Record field access)
- IF
- CASE
- LET (though LET has no unit tests yet)
- Parentheses